### PR TITLE
Char Default Value should be wrapped in single quotes

### DIFF
--- a/src/Rocks.Tests/Extensions/ObjectExtensionsTests.cs
+++ b/src/Rocks.Tests/Extensions/ObjectExtensionsTests.cs
@@ -21,7 +21,7 @@ public static class ObjectExtensionsTests
 	[TestCase("public class Test { public void Foo(sbyte value = 22) { } }", "22")]
 	[TestCase("public class Test { public void Foo(char value = char.MaxValue) { } }", "char.MaxValue")]
 	[TestCase("public class Test { public void Foo(char value = char.MinValue) { } }", "char.MinValue")]
-	[TestCase("public class Test { public void Foo(char value = 'A') { } }", "A")]
+	[TestCase("public class Test { public void Foo(char value = 'A') { } }", "'A'")]
 	[TestCase("public class Test { public void Foo(double value = double.PositiveInfinity) { } }", "double.PositiveInfinity")]
 	[TestCase("public class Test { public void Foo(double value = double.NegativeInfinity) { } }", "double.NegativeInfinity")]
 	[TestCase("public class Test { public void Foo(double value = double.MaxValue) { } }", "double.MaxValue")]

--- a/src/Rocks/Extensions/ObjectExtensions.cs
+++ b/src/Rocks/Extensions/ObjectExtensions.cs
@@ -60,7 +60,7 @@ internal static class ObjectExtensions
 		{
 			char.MaxValue => "char.MaxValue",
 			char.MinValue => "char.MinValue",
-			_ => self.ToString()
+			_ => $"'{self}'"
 		};
 
 	private static string GetDecimalDefaultValue(this decimal self) =>


### PR DESCRIPTION
When a char default value has a non min/max value, it should be wrapped in single quotes.